### PR TITLE
Ability to Proxy requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+test.ts
 dist
 node_modules
 npm-debug*

--- a/package.json
+++ b/package.json
@@ -2,10 +2,9 @@
   "name": "porter-server",
   "version": "1.0.16",
   "description": "A basic server to be used with Node including Server, Database and console logging.",
-  "repository" :
-  {
-    "type" : "git",
-    "url" : "https://github.com/vultuk/porter-server"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vultuk/porter-server"
   },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -17,14 +16,15 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "rimraf": "^2.5.4",
-    "typescript": "^2.1.4",
     "@types/body-parser": "^1.16.3",
     "@types/express": "^4.0.35",
     "bluebird": "^3.5.0",
     "body-parser": "^1.17.1",
     "express": "^4.15.2",
     "pg-promise": "^5.6.7",
-    "pusher": "^1.5.1"
+    "pusher": "^1.5.1",
+    "request": "^2.81.0",
+    "rimraf": "^2.5.4",
+    "typescript": "^2.1.4"
   }
 }

--- a/src/controllers/proxy.controller.ts
+++ b/src/controllers/proxy.controller.ts
@@ -1,0 +1,33 @@
+import {Controller} from "../models/controller.model";
+import * as request from 'request';
+
+export class ProxyController extends Controller {
+    private proxyUrl: string;
+
+    public setProxyUrl(proxyUrl: string): this {
+        this.proxyUrl = proxyUrl;
+
+        return this;
+    }
+
+    public proxy() {
+        let headers = this.request.headers;
+        request({
+            url: this.generateProxyUrl(),
+            method: this.request.method,
+            headers: {
+                'User-Agent': headers['user-agent'],
+                'Content-Type': headers['content-type'],
+                'Authorization': headers['authorization'],
+            }
+        }, (e,r,body) => {
+            this.response.status(r.statusCode);
+            this.response.set(r.headers);
+            this.response.end(body);
+        });
+    }
+
+    private generateProxyUrl(): string {
+        return `${this.proxyUrl}${this.request.url}`;
+    }
+}

--- a/src/types/requests/request.type.ts
+++ b/src/types/requests/request.type.ts
@@ -3,6 +3,7 @@ import {Controller} from "../../models/controller.model";
 export class Request {
     endpoint: string;
     method: string;
-    controller: typeof Controller;
+    controller?: typeof Controller;
     action?: string;
+    proxyUrl?: string;
 }


### PR DESCRIPTION
There is now the ability to proxy requests for either single routes
or for a whole resource. This enables any system to call external
APIs or other microservices without any extra implementation.

Proxying to another server is as simple as adding a proxyUrl field
to the appropriate Request object.